### PR TITLE
remove np.asfarray as it was deprecated in Numpy 2.0

### DIFF
--- a/dbcv/core.py
+++ b/dbcv/core.py
@@ -223,7 +223,7 @@ def dbcv(
            https://www.dbs.ifi.lmu.de/~zimek/publications/SDM2014/DBCV.pdf
     .. [2] https://github.com/pajaskowiak/dbcv/
     """
-    X = np.asfarray(X)
+    X = np.asarray(X, dtype=np.float64)
 
     if X.ndim == 1:
         X = X.reshape(-1, 1)


### PR DESCRIPTION
Hi i have remove the call to np.asfarray as it was deprecated in version 2.0 of Numpy. I have change it to np.asarray with a dtype np.float64 which does the same and is compatible with the new version.